### PR TITLE
change api path for product service

### DIFF
--- a/src/components/pages/PageProducts/components/Products.tsx
+++ b/src/components/pages/PageProducts/components/Products.tsx
@@ -1,26 +1,25 @@
-import React, {useEffect, useState} from 'react';
-import Card from '@material-ui/core/Card';
-import CardActions from '@material-ui/core/CardActions';
-import CardContent from '@material-ui/core/CardContent';
-import CardMedia from '@material-ui/core/CardMedia';
-import Grid from '@material-ui/core/Grid';
-import Typography from '@material-ui/core/Typography';
-import {makeStyles} from '@material-ui/core/styles';
-import {Product} from "models/Product";
-import {formatAsPrice} from "utils/utils";
+import React, { useEffect, useState } from "react";
+import Card from "@material-ui/core/Card";
+import CardActions from "@material-ui/core/CardActions";
+import CardContent from "@material-ui/core/CardContent";
+import CardMedia from "@material-ui/core/CardMedia";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/core/styles";
+import { Product } from "models/Product";
+import { formatAsPrice } from "utils/utils";
 import AddProductToCart from "components/AddProductToCart/AddProductToCart";
-// import axios from 'axios';
-// import API_PATHS from "constants/apiPaths";
-import productList from "./productList.json";
+import axios from "axios";
+import API_PATHS from "constants/apiPaths";
 
 const useStyles = makeStyles((theme) => ({
   card: {
-    height: '100%',
-    display: 'flex',
-    flexDirection: 'column',
+    height: "100%",
+    display: "flex",
+    flexDirection: "column",
   },
   cardMedia: {
-    paddingTop: '56.25%', // 16:9
+    paddingTop: "56.25%", // 16:9
   },
   cardContent: {
     flexGrow: 1,
@@ -36,10 +35,10 @@ export default function Products() {
   const [products, setProducts] = useState<Product[]>([]);
 
   useEffect(() => {
-    // axios.get(`${API_PATHS.bff}/product/available/`)
-    //   .then(res => setProducts(res.data));
-    setProducts(productList);
-  }, [])
+    axios
+      .get(`${API_PATHS.bff}/products/`)
+      .then((res) => setProducts(res.data));
+  }, []);
 
   return (
     <Grid container spacing={4}>
@@ -55,12 +54,10 @@ export default function Products() {
               <Typography gutterBottom variant="h5" component="h2">
                 {product.title}
               </Typography>
-              <Typography>
-                {formatAsPrice(product.price)}
-              </Typography>
+              <Typography>{formatAsPrice(product.price)}</Typography>
             </CardContent>
             <CardActions>
-              <AddProductToCart product={product}/>
+              <AddProductToCart product={product} />
             </CardActions>
           </Card>
         </Grid>

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
-
 const API_PATHS = {
-  product: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-  order: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-  import: 'https://.execute-api.eu-west-1.amazonaws.com/dev',
-  bff: 'https://.execute-api.eu-west-1.amazonaws.com/dev'
+  product:
+    "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/products",
+  order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+  bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
 };
 
 export default API_PATHS;

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
 const API_PATHS = {
   product:
-    "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/products",
-  order: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  import: "https://.execute-api.eu-west-1.amazonaws.com/dev",
-  bff: "https://.execute-api.eu-west-1.amazonaws.com/dev",
+    "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
+  order: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
+  import: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
+  bff: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
 };
 
 export default API_PATHS;

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -1,9 +1,9 @@
 const API_PATHS = {
   product:
-    "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
-  order: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
-  import: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
-  bff: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/",
+    "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev",
+  order: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev",
+  import: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev",
+  bff: "https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev",
 };
 
 export default API_PATHS;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ axios.interceptors.response.use(
     return response;
   },
   function(error) {
-    if (error.response.status === 400) {
+    if (error.response?.status === 400) {
       alert(error.response.data?.data);
     }
     return Promise.reject(error.response);


### PR DESCRIPTION
What was done: 
- [x] serverless.ts contains configuration for 2 lambda functions, API is working, configuration is correct
- [x] The getProductsList lambda function returns a correct response
- [x] The getProductsById AND getProductsList lambda functions return a correct response code
- [x] Frontend application is integrated with product service (/products API) and products from product-service are represented on Frontend. 

- [x] Async/await is used in lambda functions
- [x] ES6 modules are used for product-service implementation
- [x] Webpack is configured for product-service
- [x] SWAGGER documentation is created for product-service
- [x] Lambda handlers are covered by basic UNIT tests (NO infrastructure logic is needed to be covered) (You may use JEST)
- [x] Lambda handlers (getProductsList, getProductsById) code is written not in 1 single module (file) and separated in codebase.
- [x] Main error scenarious are handled by API ("Product not found" error, try catch blocks are used in lambda handlers).

link to rs-app: https://dw4ybzvdvnbrp.cloudfront.net/
getProductsList link: https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/products
getProductById link: https://058jzn8nx9.execute-api.eu-west-1.amazonaws.com/dev/products/id (ids from 0 to 7)
backend mr link: https://github.com/Romicusblr/nodejs-aws-be/pull/2
swagger link: https://app.swaggerhub.com/apis/Romicusblr/rs-app/0.0.2